### PR TITLE
Use single Salsa input

### DIFF
--- a/new-salsa/benches/compare.rs
+++ b/new-salsa/benches/compare.rs
@@ -4,6 +4,9 @@ use new_salsa::Database;
 fn compare(c: &mut Criterion) {
     let mut group = c.benchmark_group("compare");
     let mut db = Database::default();
+
+    let input = new_salsa::Input::new(&db, String::new());
+
     for n in &[1] {
         group.bench_function(BenchmarkId::new("new_salsa_constant", n), |b| {
             // let text = std::iter::repeat("A").take(*n).collect::<String>();
@@ -14,7 +17,7 @@ fn compare(c: &mut Criterion) {
     for n in &[1] {
         group.bench_function(BenchmarkId::new("new_salsa_length", n), |b| {
             let text = std::iter::repeat("A").take(*n).collect::<String>();
-            b.iter(|| new_salsa::run_length(&mut db, text.clone()))
+            b.iter(|| new_salsa::run_length(&mut db, input, text.clone()))
         });
     }
 

--- a/new-salsa/src/lib.rs
+++ b/new-salsa/src/lib.rs
@@ -31,8 +31,8 @@ impl Db for Database {
 
 impl salsa::Database for Database {}
 
-pub fn run_length(db: &mut Database, text: String) {
-    let input = db.set_text(text);
+pub fn run_length(db: &mut Database, input: Input, text: String) {
+    input.set_text(db).to(text);
     length(db, input);
 }
 


### PR DESCRIPTION
This PR changes the new-salsa benchmark to use the same salsa input instead of creating a new salsa input on each iteration. 
I think that's closer to what the old salsa implementation does (setting the text of a single key).

The "new" salsa is still about twice as slow

```
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/compare.rs (target/release/deps/compare-3de1992c0859da6d)
Gnuplot not found, using plotters backend
compare/new_salsa_constant/1
                        time:   [33.704 ns 33.787 ns 33.893 ns]
                        change: [-2.9527% -2.6793% -2.4131%] (p = 0.00 < 0.05)
                        Performance has improved.
compare/new_salsa_length/1
                        time:   [358.24 ns 358.46 ns 358.72 ns]
                        change: [-2.6778% -2.5935% -2.5134%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) low mild
  1 (1.00%) high severe

     Running unittests src/lib.rs (target/release/deps/old_salsa-eb67693847390dac)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/compare.rs (target/release/deps/compare-97fb056f3cb1d033)
Gnuplot not found, using plotters backend
compare/old_salsa_constant/1
                        time:   [19.032 ns 19.047 ns 19.063 ns]
                        change: [-5.0335% -4.7931% -4.5939%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
compare/old_salsa/1     time:   [190.25 ns 190.70 ns 191.43 ns]
                        change: [+1.8572% +2.1860% +2.6444%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
```
